### PR TITLE
Correcting URI for setting metadata headers on a container sample

### DIFF
--- a/docs-ref-conceptual/storageservices/Setting-and-Retrieving-Properties-and-Metadata-for-Blob-Resources.md
+++ b/docs-ref-conceptual/storageservices/Setting-and-Retrieving-Properties-and-Metadata-for-Blob-Resources.md
@@ -76,7 +76,7 @@ GET/HEAD https://myaccount.blob.core.windows.net/mycontainer/myblob?comp=metadat
  The URI syntax for setting metadata headers on a container is as follows:  
   
 ```  
-PUT https://myaccount.blob.core.windows.net/mycontainer?comp=metadata?restype=container  
+PUT https://myaccount.blob.core.windows.net/mycontainer?comp=metadata&restype=container  
 ```  
   
  The URI syntax for setting metadata headers on a blob is as follows:  


### PR DESCRIPTION
The URI contains two question marks which is not correct. the second parameter should begin with an ampersand symbol instead